### PR TITLE
Build without gzip fixed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -460,14 +460,10 @@ endif()
 	
 
 if(WINDOWS_NATIVE)
-	if(NOT DISABLE_GZIP)
-		set(CPPCMS_SOURCES ${CPPCMS_SOURCES} src/session_win32_file_storage.cpp)
-	endif()
+	set(CPPCMS_SOURCES ${CPPCMS_SOURCES} src/session_win32_file_storage.cpp)
 	set(CPPCMS_SOURCES ${CPPCMS_SOURCES} src/winservice.cpp)
 else()
-	if(NOT DISABLE_GZIP)
-		set(CPPCMS_SOURCES ${CPPCMS_SOURCES} src/session_posix_file_storage.cpp)
-	endif()
+	set(CPPCMS_SOURCES ${CPPCMS_SOURCES} src/session_posix_file_storage.cpp)
 	set(CPPCMS_SOURCES ${CPPCMS_SOURCES} src/daemonize.cpp)
 endif()
 


### PR DESCRIPTION
It seems session_posix_file_storage does not require `gzip` so inclusion of the file storage fixes #34 until the cache_frontend_test is used (called there crc32() is defined in libzip but it might have sense to implement it as a stand-alone function to avoid this dependency at all, see #36).