### PR TITLE
Strengthen CSRF validation.

### DIFF
--- a/src/session_interface.cpp
+++ b/src/session_interface.cpp
@@ -112,7 +112,7 @@ void session_interface::request_origin_validation_is_required(bool v)
 bool session_interface::validate_csrf_token(std::string const &token)
 {
 	std::string session_token = get("_csrf","");
-	return session_token.empty() || session_token == token;
+	return !session_token.empty() && !token.empty() && session_token == token;
 }
 
 void session_interface::validate_request_origin()


### PR DESCRIPTION
While doing CSRF validation, CppCMS is using "_csrf" value from the session. The "_csrf" value itself is generated in session_interface::save member function for new sessions. Validation will succeed if "_csrf" session value is empty or "_csrf" session value equals to "_csrf" POST data (or header value).

In normal situations, this works as expected because the form must be rendered before it is submitted. In the first GET request,  session is initialized and "_csrf" value is set. In the subsequent requests, the _csrf value will exist in the session; thus validation will be in place.

Now, let's consider this situation:
- Attacker gets all information about the form by inspecting HTML code.
- Then post form data with cURL without any session cookie values and hidden "_csrf" variable and header.
In this case, CppCMS will consider these requests as new session. But since "_csrf" value in the session is not generated until the response is written back; CSRF validation will succeed silently.

Maybe, we should change validate_csrf_token's logic as:
- if session[_csrf] empty, then return false.
- if token is empty, then return false.
- if session[_csrf] == token, return true; otherwise return false.
After this change, if the session is new and it's POST method and form::load is called; CSRF validation will throw an exception (as expected).

Thank you.