### PR TITLE
URL dispatcher mapping now also supports response/request mime type

### DIFF
--- a/cppcms/http_context.h
+++ b/cppcms/http_context.h
@@ -250,6 +250,12 @@ namespace cppcms {
 				set_holder(0);
 				return r;
 			}
+		
+		protected:
+			///\ the method can be used by a the dummy http context to prepare the request -> parse the content type
+			///\ note: this is needed in order to be able to test response and request media type url dispatching.
+			bool prepare_request();
+
 		private:
 
 			void set_holder(holder *p);

--- a/src/http_context.cpp
+++ b/src/http_context.cpp
@@ -58,6 +58,11 @@ context::context(booster::shared_ptr<impl::cgi::connection> conn) :
 	skin(service().views_pool().default_skin());
 }
 
+bool context::prepare_request()
+{
+	return request().prepare();
+}
+
 void context::set_holder(holder *p)
 {
 	d->specific.reset(p);
@@ -236,7 +241,7 @@ int context::on_headers_ready()
 	if(!pool)
 		return 404;
 	
-	request().prepare();
+	prepare_request();
 
 	int flags;
 	

--- a/tests/dummy_http_context.h
+++ b/tests/dummy_http_context.h
@@ -1,0 +1,22 @@
+///////////////////////////////////////////////////////////////////////////////
+//                                                                             
+//  Copyright (C) 2008-2012  Artyom Beilis (Tonkikh) <artyomtnk@yahoo.com>     
+//                                                                             
+//  See accompanying file COPYING.TXT file for licensing details.
+//
+///////////////////////////////////////////////////////////////////////////////
+#ifndef CPPCMS_IMPL_DUMMY_HTTP_CONTEXT_H
+#define CPPCMS_IMPL_DUMMY_HTTP_CONTEXT_H
+#include <cppcms/http_context.h>
+#include "dummy_api.h"
+
+class dummy_http_context : public cppcms::http::context {
+public:
+	dummy_http_context(booster::shared_ptr<dummy_api> conn)
+	: cppcms::http::context(conn)
+	{
+		prepare_request();
+	}
+};
+
+#endif

--- a/tests/url_mapper_test.cpp
+++ b/tests/url_mapper_test.cpp
@@ -16,6 +16,7 @@
 #include <sstream>
 #include "test.h"
 #include "dummy_api.h"
+#include "dummy_http_context.h"
 
 
 struct point {
@@ -110,18 +111,24 @@ public:
 	}
 
 	void get_0() { v_="get_0"; }
-	void get_1(int x) { v_="get_1:" + to_string(x); }
-	void get_2(int x,int y) { v_="get_2:" + to_string(x) + ":" + to_string(y); }
-	void get_3(int x,int y,int z) { v_="get_3" + ts(x)+ts(y)+ts(z); }
-	void get_4(int x,int y,int z,int t) { v_="get_4" + ts(x)+ts(y)+ts(z)+ts(t); }
+	void get_1(int a) { v_="get_1" + ts(a); }
+	void get_2(int a,int b) { v_="get_2" + ts(a)+ts(b); }
+	void get_3(int a,int b,int c) { v_="get_3" + ts(a)+ts(b)+ts(c); }
+	void get_4(int a,int b,int c,int d) { v_="get_4" + ts(a)+ts(b)+ts(c)+ts(d); }
 	void get_5(int a,int b,int c,int d,int e) { v_="get_5" + ts(a)+ts(b)+ts(c)+ts(d)+ts(e); }
 	void get_6(int a,int b,int c,int d,int e,int f) { v_="get_6" + ts(a)+ts(b)+ts(c)+ts(d)+ts(e)+ts(f); }
 	void get_7(int a,int b,int c,int d,int e,int f,int g) { v_="get_7" + ts(a)+ts(b)+ts(c)+ts(d)+ts(e)+ts(f)+ts(g); }
 	void get_8(int a,int b,int c,int d,int e,int f,int g,int h) { v_="get_8" + ts(a)+ts(b)+ts(c)+ts(d)+ts(e)+ts(f)+ts(g)+ts(h); }
 	
 	void p_0() { v_="p_0"; }
-	void p_1(int x) { v_="p_1:" + to_string(x); }
-	void p_2(int x,int y) { v_="p_2:" + to_string(x) + ":" + to_string(y); }
+	void p_1(int a) { v_="p_1" + ts(a); }
+	void p_2(int a,int b) { v_="p_2" + ts(a)+ts(b); }
+	void p_3(int a,int b,int c) { v_="p_3" + ts(a)+ts(b)+ts(c); }
+	void p_4(int a,int b,int c,int d) { v_="p_4" + ts(a)+ts(b)+ts(c)+ts(d); }
+	void p_5(int a,int b,int c,int d,int e) { v_="p_5" + ts(a)+ts(b)+ts(c)+ts(d)+ts(e); }
+	void p_6(int a,int b,int c,int d,int e,int f) { v_="p_6" + ts(a)+ts(b)+ts(c)+ts(d)+ts(e)+ts(f); }
+	void p_7(int a,int b,int c,int d,int e,int f,int g) { v_="p_7" + ts(a)+ts(b)+ts(c)+ts(d)+ts(e)+ts(f)+ts(g); }
+	void p_8(int a,int b,int c,int d,int e,int f,int g,int h) { v_="p_8" + ts(a)+ts(b)+ts(c)+ts(d)+ts(e)+ts(f)+ts(g)+ts(h); }
 
 	void point_m(point const &p) { v_="point:" + to_string(p.x) + "X" + to_string(p.y); }
 	void foo_m(stuff::foo const &p) { v_="foo:" + to_string(p.l); }
@@ -152,74 +159,407 @@ public:
 
 		dispatcher().map("/name/(.*)",&disp::h1_s,this,1);
 
-		dispatcher().map("GET","/res",&disp::get_0,this);
-		dispatcher().map("GET","/res/(a(\\d+))",&disp::get_1,this,2);
-		dispatcher().map("GET","/res/(a(\\d+))/(a(\\d+))",&disp::get_2,this,2,4);
-
-
-
-		dispatcher().map("(PUT|POST)","/res",&disp::p_0,this);
-		dispatcher().map("(PUT|POST)","/res/(a(\\d+))",&disp::p_1,this,2);
-		dispatcher().map("(PUT|POST)","/res/(a(\\d+))/(a(\\d+))",&disp::p_2,this,2,4);
-
 		dispatcher().map("/point/(.*)",&disp::point_m,this,1);
 		dispatcher().map("/foo/(.*)",&disp::foo_m,this,1);
-
-
-		dispatcher().map("GET" ,		"/res_1/(a(\\d+))/(a(\\d+))/(a(\\d+))",				&disp::get_3,this,2,4,6);
-		dispatcher().map(			"/res_2/(a(\\d+))/(a(\\d+))/(a(\\d+))",				&disp::get_3,this,2,4,6);
-		dispatcher().map("GET" ,booster::regex(	"/RES_3/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),	&disp::get_3,this,2,4,6);
-		dispatcher().map(	booster::regex(	"/RES_4/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),	&disp::get_3,this,2,4,6);
-
-
-		dispatcher().map("GET" ,		"/res_1/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",				&disp::get_4,this,2,4,6,8);
-		dispatcher().map(			"/res_2/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",				&disp::get_4,this,2,4,6,8);
-		dispatcher().map("GET" ,booster::regex(	"/RES_3/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),	&disp::get_4,this,2,4,6,8);
-		dispatcher().map(	booster::regex(	"/RES_4/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),	&disp::get_4,this,2,4,6,8);
-
-		dispatcher().map("GET" ,		"/res_1/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",				&disp::get_5,this,2,4,6,8,10);
-		dispatcher().map(			"/res_2/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",				&disp::get_5,this,2,4,6,8,10);
-		dispatcher().map("GET" ,booster::regex(	"/RES_3/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),	&disp::get_5,this,2,4,6,8,10);
-		dispatcher().map(	booster::regex(	"/RES_4/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),	&disp::get_5,this,2,4,6,8,10);
-
-		dispatcher().map("GET" ,		"/res_1/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",				&disp::get_6,this,2,4,6,8,10,12);
-		dispatcher().map(			"/res_2/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",				&disp::get_6,this,2,4,6,8,10,12);
-		dispatcher().map("GET" ,booster::regex(	"/RES_3/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),	&disp::get_6,this,2,4,6,8,10,12);
-		dispatcher().map(	booster::regex(	"/RES_4/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),	&disp::get_6,this,2,4,6,8,10,12);
 		
-		dispatcher().map("GET" ,		
-				 "/res_1/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
-				&disp::get_7,this,2,4,6,8,10,12,14);
+		dispatcher().map("GET",
+						 "/res_1",
+						 &disp::get_0,this);
+		dispatcher().map("(PUT|POST)",
+						 "/res_1",
+						 &disp::p_0,this);
+		dispatcher().map("GET",
+						 "/res_1/(a(\\d+))",
+						 &disp::get_1,this,2);
+		dispatcher().map("(PUT|POST)",
+						 "/res_1/(a(\\d+))",
+						 &disp::p_1,this,2);
+		dispatcher().map("GET",
+						 "/res_1/(a(\\d+))/(a(\\d+))",
+						 &disp::get_2,this,2,4);
+		dispatcher().map("(PUT|POST)",
+						 "/res_1/(a(\\d+))/(a(\\d+))",
+						 &disp::p_2,this,2,4);
+		dispatcher().map("GET",
+						 "/res_1/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::get_3,this,2,4,6);
+		dispatcher().map("(PUT|POST)",
+						 "/res_1/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::p_3,this,2,4,6);
+		dispatcher().map("GET",
+						 "/res_1/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::get_4,this,2,4,6,8);
+		dispatcher().map("(PUT|POST)",
+						 "/res_1/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::p_4,this,2,4,6,8);
+		dispatcher().map("GET",
+						 "/res_1/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::get_5,this,2,4,6,8,10);
+		dispatcher().map("(PUT|POST)",
+						 "/res_1/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::p_5,this,2,4,6,8,10);
+		dispatcher().map("GET",
+						 "/res_1/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::get_6,this,2,4,6,8,10,12);
+		dispatcher().map("(PUT|POST)",
+						 "/res_1/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::p_6,this,2,4,6,8,10,12);
+		dispatcher().map("GET",
+						 "/res_1/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::get_7,this,2,4,6,8,10,12,14);
+		dispatcher().map("(PUT|POST)",
+						 "/res_1/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::p_7,this,2,4,6,8,10,12,14);
+		dispatcher().map("GET",
+						 "/res_1/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::get_8,this,2,4,6,8,10,12,14,16);
+		dispatcher().map("(PUT|POST)",
+						 "/res_1/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::p_8,this,2,4,6,8,10,12,14,16);
 
-		dispatcher().map("/res_2/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",				
-				&disp::get_7,this,2,4,6,8,10,12,14);
+		dispatcher().map("/res_2",
+						 &disp::get_0,this);
+		dispatcher().map("/res_2/(a(\\d+))",
+						 &disp::get_1,this,2);
+		dispatcher().map("/res_2/(a(\\d+))/(a(\\d+))",
+						 &disp::get_2,this,2,4);
+		dispatcher().map("/res_2/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::get_3,this,2,4,6);
+		dispatcher().map("/res_2/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::get_4,this,2,4,6,8);
+		dispatcher().map("/res_2/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::get_5,this,2,4,6,8,10);
+		dispatcher().map("/res_2/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::get_6,this,2,4,6,8,10,12);
+		dispatcher().map("/res_2/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::get_7,this,2,4,6,8,10,12,14);
+		dispatcher().map("/res_2/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::get_8,this,2,4,6,8,10,12,14,16);
 
-		dispatcher().map("GET" ,
-		  booster::regex("/RES_3/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),	
-		  		&disp::get_7,this,2,4,6,8,10,12,14);
+		dispatcher().map("GET",
+						 booster::regex("/RES_3",booster::regex::icase),
+						 &disp::get_0,this);
+		dispatcher().map("(PUT|POST)",
+						 booster::regex("/RES_3",booster::regex::icase),
+						 &disp::p_0,this);
+		dispatcher().map("GET",
+						 booster::regex("/RES_3/(a(\\d+))",booster::regex::icase),
+						 &disp::get_1,this,2);
+		dispatcher().map("(PUT|POST)",
+						 booster::regex("/RES_3/(a(\\d+))",booster::regex::icase),
+						 &disp::p_1,this,2);
+		dispatcher().map("GET",
+						 booster::regex("/RES_3/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::get_2,this,2,4);
+		dispatcher().map("(PUT|POST)",
+						 booster::regex("/RES_3/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::p_2,this,2,4);
+		dispatcher().map("GET",
+						 booster::regex("/RES_3/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::get_3,this,2,4,6);
+		dispatcher().map("(PUT|POST)",
+						 booster::regex("/RES_3/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::p_3,this,2,4,6);
+		dispatcher().map("GET",
+						 booster::regex("/RES_3/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::get_4,this,2,4,6,8);
+		dispatcher().map("(PUT|POST)",
+						 booster::regex("/RES_3/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::p_4,this,2,4,6,8);
+		dispatcher().map("GET",
+						 booster::regex("/RES_3/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::get_5,this,2,4,6,8,10);
+		dispatcher().map("(PUT|POST)",
+						 booster::regex("/RES_3/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::p_5,this,2,4,6,8,10);
+		dispatcher().map("GET",
+						 booster::regex("/RES_3/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::get_6,this,2,4,6,8,10,12);
+		dispatcher().map("(PUT|POST)",
+						 booster::regex("/RES_3/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::p_6,this,2,4,6,8,10,12);
+		dispatcher().map("GET",
+						 booster::regex("/RES_3/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+		  				 &disp::get_7,this,2,4,6,8,10,12,14);
+		dispatcher().map("(PUT|POST)",
+						 booster::regex("/RES_3/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+		  				 &disp::p_7,this,2,4,6,8,10,12,14);
+		dispatcher().map("GET",
+						 booster::regex("/RES_3/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::get_8,this,2,4,6,8,10,12,14,16);
+		dispatcher().map("(PUT|POST)",
+						 booster::regex("/RES_3/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::p_8,this,2,4,6,8,10,12,14,16);
 
-		dispatcher().map(
-		  booster::regex("/RES_4/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),	
-		  		&disp::get_7,this,2,4,6,8,10,12,14);
-
-		dispatcher().map("GET" ,		
-				 "/res_1/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
-				&disp::get_8,this,2,4,6,8,10,12,14,16);
-
-		dispatcher().map("/res_2/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",				
-				&disp::get_8,this,2,4,6,8,10,12,14,16);
-
-		dispatcher().map("GET" ,
-		  booster::regex("/RES_3/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),	
-		  		&disp::get_8,this,2,4,6,8,10,12,14,16);
-
-		dispatcher().map(
-		  booster::regex("/RES_4/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),	
-		  		&disp::get_8,this,2,4,6,8,10,12,14,16);
+		dispatcher().map(booster::regex("/RES_4",booster::regex::icase),
+						 &disp::get_0,this);
+		dispatcher().map(booster::regex("/RES_4/(a(\\d+))",booster::regex::icase),
+						 &disp::get_1,this,2);
+		dispatcher().map(booster::regex("/RES_4/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::get_2,this,2,4);
+		dispatcher().map(booster::regex("/RES_4/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::get_3,this,2,4,6);
+		dispatcher().map(booster::regex("/RES_4/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::get_4,this,2,4,6,8);
+		dispatcher().map(booster::regex("/RES_4/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::get_5,this,2,4,6,8,10);
+		dispatcher().map(booster::regex("/RES_4/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::get_6,this,2,4,6,8,10,12);
+		dispatcher().map(booster::regex("/RES_4/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::get_7,this,2,4,6,8,10,12,14);
+		dispatcher().map(booster::regex("/RES_4/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::get_8,this,2,4,6,8,10,12,14,16);
+		
+		dispatcher().map("GET",
+						 "text/html",
+						 "/res_5",
+						 &disp::get_0,this);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "/res_5",
+						 &disp::p_0,this);
+		dispatcher().map("GET",
+						 "text/html",
+						 "/res_5/(a(\\d+))",
+						 &disp::get_1,this,2);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "/res_5/(a(\\d+))",
+						 &disp::p_1,this,2);
+		dispatcher().map("GET",
+						 "text/html",
+						 "/res_5/(a(\\d+))/(a(\\d+))",
+						 &disp::get_2,this,2,4);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "/res_5/(a(\\d+))/(a(\\d+))",
+						 &disp::p_2,this,2,4);
+		dispatcher().map("GET",
+						 "text/html",
+						 "/res_5/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::get_3,this,2,4,6);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "/res_5/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::p_3,this,2,4,6);
+		dispatcher().map("GET",
+						 "text/html",
+						 "/res_5/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::get_4,this,2,4,6,8);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "/res_5/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::p_4,this,2,4,6,8);
+		dispatcher().map("GET",
+						 "text/html",
+						 "/res_5/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::get_5,this,2,4,6,8,10);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "/res_5/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::p_5,this,2,4,6,8,10);
+		dispatcher().map("GET",
+						 "text/html",
+						 "/res_5/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::get_6,this,2,4,6,8,10,12);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "/res_5/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::p_6,this,2,4,6,8,10,12);
+		dispatcher().map("GET",
+						 "text/html",
+						 "/res_5/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::get_7,this,2,4,6,8,10,12,14);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "/res_5/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::p_7,this,2,4,6,8,10,12,14);
+		dispatcher().map("GET",
+						 "text/html",
+						 "/res_5/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::get_8,this,2,4,6,8,10,12,14,16);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "/res_5/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::p_8,this,2,4,6,8,10,12,14,16);
+		
+		dispatcher().map("GET",
+						 "text/html",
+						 booster::regex("/RES_6",booster::regex::icase),
+						 &disp::get_0,this);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 booster::regex("/RES_6",booster::regex::icase),
+						 &disp::p_0,this);
+		dispatcher().map("GET",
+						 "text/html",
+						 booster::regex("/RES_6/(a(\\d+))",booster::regex::icase),
+						 &disp::get_1,this,2);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 booster::regex("/RES_6/(a(\\d+))",booster::regex::icase),
+						 &disp::p_1,this,2);
+		dispatcher().map("GET",
+						 "text/html",
+						 booster::regex("/RES_6/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::get_2,this,2,4);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 booster::regex("/RES_6/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::p_2,this,2,4);
+		dispatcher().map("GET",
+						 "text/html",
+						 booster::regex("/RES_6/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::get_3,this,2,4,6);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 booster::regex("/RES_6/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::p_3,this,2,4,6);
+		dispatcher().map("GET",
+						 "text/html",
+						 booster::regex("/RES_6/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::get_4,this,2,4,6,8);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 booster::regex("/RES_6/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::p_4,this,2,4,6,8);
+		dispatcher().map("GET",
+						 "text/html",
+						 booster::regex("/RES_6/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::get_5,this,2,4,6,8,10);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 booster::regex("/RES_6/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::p_5,this,2,4,6,8,10);
+		dispatcher().map("GET",
+						 "text/html",
+						 booster::regex("/RES_6/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::get_6,this,2,4,6,8,10,12);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 booster::regex("/RES_6/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::p_6,this,2,4,6,8,10,12);
+		dispatcher().map("GET",
+						 "text/html",
+						 booster::regex("/RES_6/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::get_7,this,2,4,6,8,10,12,14);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 booster::regex("/RES_6/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::p_7,this,2,4,6,8,10,12,14);
+		dispatcher().map("GET",
+						 "text/html",
+		  				 booster::regex("/RES_6/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+		  				 &disp::get_8,this,2,4,6,8,10,12,14,16);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+		  				 booster::regex("/RES_6/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+		  				 &disp::p_8,this,2,4,6,8,10,12,14,16);
+		
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "application/x-www-form-urlencoded",
+						 "/res_7",
+						 &disp::p_0,this);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "application/x-www-form-urlencoded",
+						 "/res_7/(a(\\d+))",
+						 &disp::p_1,this,2);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "application/x-www-form-urlencoded",
+						 "/res_7/(a(\\d+))/(a(\\d+))",
+						 &disp::p_2,this,2,4);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "application/x-www-form-urlencoded",
+						 "/res_7/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::p_3,this,2,4,6);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "application/x-www-form-urlencoded",
+						 "/res_7/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::p_4,this,2,4,6,8);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "application/x-www-form-urlencoded",
+						 "/res_7/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::p_5,this,2,4,6,8,10);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "application/x-www-form-urlencoded",
+						 "/res_7/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::p_6,this,2,4,6,8,10,12);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "application/x-www-form-urlencoded",
+						 "/res_7/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::p_7,this,2,4,6,8,10,12,14);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "application/x-www-form-urlencoded",
+						 "/res_7/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::p_7,this,2,4,6,8,10,12,14);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "application/x-www-form-urlencoded",
+						 "/res_7/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",
+						 &disp::p_8,this,2,4,6,8,10,12,14,16);
+		
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "application/x-www-form-urlencoded",
+						 booster::regex("/RES_8",booster::regex::icase),
+						 &disp::p_0,this);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "application/x-www-form-urlencoded",
+						 booster::regex("/RES_8/(a(\\d+))",booster::regex::icase),
+						 &disp::p_1,this,2);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "application/x-www-form-urlencoded",
+						 booster::regex("/RES_8/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::p_2,this,2,4);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "application/x-www-form-urlencoded",
+						 booster::regex("/RES_8/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::p_3,this,2,4,6);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "application/x-www-form-urlencoded",
+						 booster::regex("/RES_8/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::p_4,this,2,4,6,8);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "application/x-www-form-urlencoded",
+						 booster::regex("/RES_8/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::p_5,this,2,4,6,8,10);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "application/x-www-form-urlencoded",
+						 booster::regex("/RES_8/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::p_6,this,2,4,6,8,10,12);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "application/x-www-form-urlencoded",
+						 booster::regex("/RES_8/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+						 &disp::p_7,this,2,4,6,8,10,12,14);
+		dispatcher().map("(PUT|POST)",
+						 "text/html",
+						 "application/x-www-form-urlencoded",
+		  				 booster::regex("/RES_8/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))/(a(\\d+))",booster::regex::icase),
+		  				 &disp::p_8,this,2,4,6,8,10,12,14,16);
 	}
 #define TESTD(x,y) do { main(x); TEST(v_==y); } while(0)
 
 #define TESTM(m,x,y) do { v_="none"; set_context((m)); main((x)); release_context() ; if(v_!=(y))  std::cerr << "v=" <<v_ << " exp="<< (y) <<std::endl; TEST(v_==(y)); } while(0)
+
+#define TESTMA(m,a,x,y) do { v_="none"; set_context((m),(a)); main((x)); release_context() ; if(v_!=(y))  std::cerr << "v=" <<v_ << " exp="<< (y) <<std::endl; TEST(v_==(y)); } while(0)
+
+#define TESTMACT(m,a,ct,x,y) do { v_="none"; set_context((m),(a),(ct)); main((x)); release_context() ; if(v_!=(y))  std::cerr << "v=" <<v_ << " exp="<< (y) <<std::endl; TEST(v_==(y)); } while(0)
 
 	void test()
 	{
@@ -231,7 +571,6 @@ public:
 		TESTD("h4/a1/a2/a3/a4",":1:2:3:4");
 		TESTD("h5/a1/a2/a3/a4/a5",":1:2:3:4:5");
 		TESTD("h6/a1/a2/a3/a4/a5/a6",":1:2:3:4:5:6");
-
 
 		TESTM("GET","/h0","-");
 		TESTM("GET","/rh0","-");
@@ -251,22 +590,6 @@ public:
 			   "h1_s:\xD7\xA9\xD7\x9C\xD7\x95\xD7\x9D\x20\xE6\x97\xA5\xE6\x9C\xAC\xE8\xAA\x9E");
 		TESTM("GET","/name/\xFF","none");
 
-		TESTM("GET","/res","get_0");
-		TESTM("GET","/res/a1","get_1:to_str(1)");
-		TESTM("GET","/res/a1/a2","get_2:to_str(1):to_str(2)");
-		
-		TESTM("POST","/res","p_0");
-		TESTM("POST","/res/a1","p_1:to_str(1)");
-		TESTM("POST","/res/a1/a2","p_2:to_str(1):to_str(2)");
-
-		TESTM("PUT","/res","p_0");
-		TESTM("PUT","/res/a1","p_1:to_str(1)");
-		TESTM("PUT","/res/a1/a2","p_2:to_str(1):to_str(2)");
-
-		TESTM("DELETE","/res","none");
-		TESTM("DELETE","/res/a1","none");
-		TESTM("DELETE","/res/a1/a2","none");
-
 		TESTM("GET","/point/123,23","point:to_str(123)Xto_str(23)");
 		TESTM("GET","/point/123","none");
 		TESTM("GET","/point/123,23.2","none");
@@ -274,51 +597,1170 @@ public:
 		TESTM("GET","/foo/abcd","foo:to_str(4)");
 		TESTM("GET","/foo/abcdefg","foo:to_str(7)");
 		
+		TESTM("GET","/res_1","get_0");
+		TESTMA("GET","application/json","/res_1","get_0");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_1","get_0");
+		TESTM("PUT","/res_1","p_0");
+		TESTMA("PUT","application/json","/res_1","p_0");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_1","p_0");
+		TESTM("POST","/res_1","p_0");
+		TESTMA("POST","application/json","/res_1","p_0");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_1","p_0");
+		TESTM("DELETE","/res_1","none");
+		TESTMA("DELETE","application/json","/res_1","none");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_1","none");
+		TESTM("GET","/res_1/a1","get_1:1");
+		TESTMA("GET","application/json","/res_1/a1","get_1:1");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_1/a1","get_1:1");
+		TESTM("PUT","/res_1/a1","p_1:1");
+		TESTMA("PUT","application/json","/res_1/a1","p_1:1");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_1/a1","p_1:1");
+		TESTM("POST","/res_1/a1","p_1:1");
+		TESTMA("POST","application/json","/res_1/a1","p_1:1");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_1/a1","p_1:1");
+		TESTM("DELETE","/res_1/a1","none");
+		TESTMA("DELETE","application/json","/res_1/a1","none");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_1/a1","none");
+		TESTM("GET","/res_1/a1/a2","get_2:1:2");
+		TESTMA("GET","application/json","/res_1/a1/a2","get_2:1:2");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_1/a1/a2","get_2:1:2");
+		TESTM("PUT","/res_1/a1/a2","p_2:1:2");
+		TESTMA("PUT","application/json","/res_1/a1/a2","p_2:1:2");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_1/a1/a2","p_2:1:2");
+		TESTM("POST","/res_1/a1/a2","p_2:1:2");
+		TESTMA("POST","application/json","/res_1/a1/a2","p_2:1:2");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_1/a1/a2","p_2:1:2");
+		TESTM("DELETE","/res_1/a1/a2","none");
+		TESTMA("DELETE","application/json","/res_1/a1/a2","none");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_1/a1/a2","none");
 		TESTM("GET","/res_1/a1/a2/a3","get_3:1:2:3");
-		TESTM("GET","/res_2/a1/a2/a3","get_3:1:2:3");
-		TESTM("GET","/res_3/a1/a2/a3","get_3:1:2:3");
-		TESTM("GET","/res_4/a1/a2/a3","get_3:1:2:3");
-		
+		TESTMA("GET","application/json","/res_1/a1/a2/a3","get_3:1:2:3");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_1/a1/a2/a3","get_3:1:2:3");
+		TESTM("PUT","/res_1/a1/a2/a3","p_3:1:2:3");
+		TESTMA("PUT","application/json","/res_1/a1/a2/a3","p_3:1:2:3");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_1/a1/a2/a3","p_3:1:2:3");
+		TESTM("POST","/res_1/a1/a2/a3","p_3:1:2:3");
+		TESTMA("POST","application/json","/res_1/a1/a2/a3","p_3:1:2:3");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_1/a1/a2/a3","p_3:1:2:3");
+		TESTM("DELETE","/res_1/a1/a2/a3","none");
+		TESTMA("DELETE","application/json","/res_1/a1/a2/a3","none");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_1/a1/a2/a3","none");
 		TESTM("GET","/res_1/a1/a2/a3/a4","get_4:1:2:3:4");
-		TESTM("GET","/res_2/a1/a2/a3/a4","get_4:1:2:3:4");
-		TESTM("GET","/res_3/a1/a2/a3/a4","get_4:1:2:3:4");
-		TESTM("GET","/res_4/a1/a2/a3/a4","get_4:1:2:3:4");
-		
+		TESTMA("GET","application/json","/res_1/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_1/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTM("PUT","/res_1/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTMA("PUT","application/json","/res_1/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_1/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTM("POST","/res_1/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTMA("POST","application/json","/res_1/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_1/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTM("DELETE","/res_1/a1/a2/a3/a4","none");
+		TESTMA("DELETE","application/json","/res_1/a1/a2/a3/a4","none");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_1/a1/a2/a3/a4","none");
 		TESTM("GET","/res_1/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
-		TESTM("GET","/res_2/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
-		TESTM("GET","/res_3/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
-		TESTM("GET","/res_4/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
-
+		TESTMA("GET","application/json","/res_1/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_1/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTM("PUT","/res_1/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTMA("PUT","application/json","/res_1/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_1/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTM("POST","/res_1/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTMA("POST","application/json","/res_1/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_1/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTM("DELETE","/res_1/a1/a2/a3/a4/a5","none");
+		TESTMA("DELETE","application/json","/res_1/a1/a2/a3/a4/a5","none");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_1/a1/a2/a3/a4/a5","none");
 		TESTM("GET","/res_1/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
-		TESTM("GET","/res_2/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
-		TESTM("GET","/res_3/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
-		TESTM("GET","/res_4/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
-		
+		TESTMA("GET","application/json","/res_1/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_1/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTM("PUT","/res_1/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTMA("PUT","application/json","/res_1/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_1/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTM("POST","/res_1/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTMA("POST","application/json","/res_1/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_1/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTM("DELETE","/res_1/a1/a2/a3/a4/a5/a6","none");
+		TESTMA("DELETE","application/json","/res_1/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_1/a1/a2/a3/a4/a5/a6","none");
 		TESTM("GET","/res_1/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
-		TESTM("GET","/res_2/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
-		TESTM("GET","/res_3/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
-		TESTM("GET","/res_4/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
-
+		TESTMA("GET","application/json","/res_1/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_1/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTM("PUT","/res_1/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTMA("PUT","application/json","/res_1/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_1/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTM("POST","/res_1/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTMA("POST","application/json","/res_1/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_1/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTM("DELETE","/res_1/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMA("DELETE","application/json","/res_1/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_1/a1/a2/a3/a4/a5/a6/a7","none");
 		TESTM("GET","/res_1/a1/a2/a3/a4/a5/a6/a7/a8","get_8:1:2:3:4:5:6:7:8");
-		TESTM("GET","/res_2/a1/a2/a3/a4/a5/a6/a7/a8","get_8:1:2:3:4:5:6:7:8");
+		TESTMA("GET","application/json","/res_1/a1/a2/a3/a4/a5/a6/a7/a8","get_8:1:2:3:4:5:6:7:8");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_1/a1/a2/a3/a4/a5/a6/a7/a8","get_8:1:2:3:4:5:6:7:8");
+		TESTM("PUT","/res_1/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTMA("PUT","application/json","/res_1/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_1/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTM("POST","/res_1/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTMA("POST","application/json","/res_1/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_1/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTM("DELETE","/res_1/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMA("DELETE","application/json","/res_1/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_1/a1/a2/a3/a4/a5/a6/a7/a8","none");
+
+		TESTM("GET","/res_2","get_0");
+		TESTMA("GET","application/json","/res_2","get_0");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_2","get_0");
+		TESTM("PUT","/res_2","get_0");
+		TESTMA("PUT","application/json","/res_2","get_0");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_2","get_0");
+		TESTM("POST","/res_2","get_0");
+		TESTMA("POST","application/json","/res_2","get_0");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_2","get_0");
+		TESTM("DELETE","/res_2","get_0");
+		TESTMA("DELETE","application/json","/res_2","get_0");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_2","get_0");
+		TESTM("GET","/res_2/a1","get_1:1");
+		TESTMA("GET","application/json","/res_2/a1","get_1:1");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_2/a1","get_1:1");
+		TESTM("PUT","/res_2/a1","get_1:1");
+		TESTMA("PUT","application/json","/res_2/a1","get_1:1");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_2/a1","get_1:1");
+		TESTM("POST","/res_2/a1","get_1:1");
+		TESTMA("POST","application/json","/res_2/a1","get_1:1");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_2/a1","get_1:1");
+		TESTM("DELETE","/res_2/a1","get_1:1");
+		TESTMA("DELETE","application/json","/res_2/a1","get_1:1");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_2/a1","get_1:1");
+		TESTM("GET","/res_2/a1/a2","get_2:1:2");
+		TESTMA("GET","application/json","/res_2/a1/a2","get_2:1:2");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_2/a1/a2","get_2:1:2");
+		TESTM("PUT","/res_2/a1/a2","get_2:1:2");
+		TESTMA("PUT","application/json","/res_2/a1/a2","get_2:1:2");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_2/a1/a2","get_2:1:2");
+		TESTM("POST","/res_2/a1/a2","get_2:1:2");
+		TESTMA("POST","application/json","/res_2/a1/a2","get_2:1:2");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_2/a1/a2","get_2:1:2");
+		TESTM("DELETE","/res_2/a1/a2","get_2:1:2");
+		TESTMA("DELETE","application/json","/res_2/a1/a2","get_2:1:2");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_2/a1/a2","get_2:1:2");
+		TESTM("GET","/res_2/a1/a2/a3","get_3:1:2:3");
+		TESTMA("GET","application/json","/res_2/a1/a2/a3","get_3:1:2:3");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_2/a1/a2/a3","get_3:1:2:3");
+		TESTM("PUT","/res_2/a1/a2/a3","get_3:1:2:3");
+		TESTMA("PUT","application/json","/res_2/a1/a2/a3","get_3:1:2:3");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_2/a1/a2/a3","get_3:1:2:3");
+		TESTM("POST","/res_2/a1/a2/a3","get_3:1:2:3");
+		TESTMA("POST","application/json","/res_2/a1/a2/a3","get_3:1:2:3");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_2/a1/a2/a3","get_3:1:2:3");
+		TESTM("DELETE","/res_2/a1/a2/a3","get_3:1:2:3");
+		TESTMA("DELETE","application/json","/res_2/a1/a2/a3","get_3:1:2:3");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_2/a1/a2/a3","get_3:1:2:3");
+		TESTM("GET","/res_2/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTMA("GET","application/json","/res_2/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_2/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTM("PUT","/res_2/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTMA("PUT","application/json","/res_2/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_2/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTM("POST","/res_2/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTMA("POST","application/json","/res_2/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_2/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTM("DELETE","/res_2/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTMA("DELETE","application/json","/res_2/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_2/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTM("GET","/res_2/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTMA("GET","application/json","/res_2/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_2/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTM("PUT","/res_2/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTMA("PUT","application/json","/res_2/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_2/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTM("POST","/res_2/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTMA("POST","application/json","/res_2/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_2/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTM("DELETE","/res_2/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTMA("DELETE","application/json","/res_2/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_2/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTM("PUT","/res_2/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTMA("PUT","application/json","/res_2/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_2/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTM("POST","/res_2/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTMA("POST","application/json","/res_2/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_2/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTM("DELETE","/res_2/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTMA("DELETE","application/json","/res_2/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_2/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTM("GET","/res_2/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTMA("GET","application/json","/res_2/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_2/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTM("PUT","/res_2/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTMA("PUT","application/json","/res_2/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_2/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTM("POST","/res_2/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTMA("POST","application/json","/res_2/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_2/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTM("DELETE","/res_2/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTMA("DELETE","application/json","/res_2/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_2/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+
+		TESTM("GET","/res_3","get_0");
+		TESTMA("GET","application/json","/res_3","get_0");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_3","get_0");
+		TESTM("PUT","/res_3","p_0");
+		TESTMA("PUT","application/json","/res_3","p_0");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_3","p_0");
+		TESTM("POST","/res_3","p_0");
+		TESTMA("POST","application/json","/res_3","p_0");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_3","p_0");
+		TESTM("DELETE","/res_3","none");
+		TESTMA("DELETE","application/json","/res_3","none");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_3","none");
+		TESTM("GET","/res_3/a1","get_1:1");
+		TESTMA("GET","application/json","/res_3/a1","get_1:1");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_3/a1","get_1:1");
+		TESTM("PUT","/res_3/a1","p_1:1");
+		TESTMA("PUT","application/json","/res_3/a1","p_1:1");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_3/a1","p_1:1");
+		TESTM("POST","/res_3/a1","p_1:1");
+		TESTMA("POST","application/json","/res_3/a1","p_1:1");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_3/a1","p_1:1");
+		TESTM("DELETE","/res_3/a1","none");
+		TESTMA("DELETE","application/json","/res_3/a1","none");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_3/a1","none");
+		TESTM("GET","/res_3/a1/a2","get_2:1:2");
+		TESTMA("GET","application/json","/res_3/a1/a2","get_2:1:2");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_3/a1/a2","get_2:1:2");
+		TESTM("PUT","/res_3/a1/a2","p_2:1:2");
+		TESTMA("PUT","application/json","/res_3/a1/a2","p_2:1:2");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_3/a1/a2","p_2:1:2");
+		TESTM("POST","/res_3/a1/a2","p_2:1:2");
+		TESTMA("POST","application/json","/res_3/a1/a2","p_2:1:2");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_3/a1/a2","p_2:1:2");
+		TESTM("DELETE","/res_3/a1/a2","none");
+		TESTMA("DELETE","application/json","/res_3/a1/a2","none");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_3/a1/a2","none");
+		TESTM("GET","/res_3/a1/a2/a3","get_3:1:2:3");
+		TESTMA("GET","application/json","/res_3/a1/a2/a3","get_3:1:2:3");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_3/a1/a2/a3","get_3:1:2:3");
+		TESTM("PUT","/res_3/a1/a2/a3","p_3:1:2:3");
+		TESTMA("PUT","application/json","/res_3/a1/a2/a3","p_3:1:2:3");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_3/a1/a2/a3","p_3:1:2:3");
+		TESTM("POST","/res_3/a1/a2/a3","p_3:1:2:3");
+		TESTMA("POST","application/json","/res_3/a1/a2/a3","p_3:1:2:3");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_3/a1/a2/a3","p_3:1:2:3");
+		TESTM("DELETE","/res_3/a1/a2/a3","none");
+		TESTMA("DELETE","application/json","/res_3/a1/a2/a3","none");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_3/a1/a2/a3","none");
+		TESTM("GET","/res_3/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTMA("GET","application/json","/res_3/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_3/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTM("PUT","/res_3/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTMA("PUT","application/json","/res_3/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_3/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTM("POST","/res_3/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTMA("POST","application/json","/res_3/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_3/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTM("DELETE","/res_3/a1/a2/a3/a4","none");
+		TESTMA("DELETE","application/json","/res_3/a1/a2/a3/a4","none");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_3/a1/a2/a3/a4","none");
+		TESTM("GET","/res_3/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTMA("GET","application/json","/res_3/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_3/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTM("PUT","/res_3/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTMA("PUT","application/json","/res_3/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_3/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTM("POST","/res_3/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTMA("POST","application/json","/res_3/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_3/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTM("DELETE","/res_3/a1/a2/a3/a4/a5","none");
+		TESTMA("DELETE","application/json","/res_3/a1/a2/a3/a4/a5","none");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_3/a1/a2/a3/a4/a5","none");
+		TESTM("GET","/res_3/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTMA("GET","application/json","/res_3/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_3/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTM("PUT","/res_3/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTMA("PUT","application/json","/res_3/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_3/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTM("POST","/res_3/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTMA("POST","application/json","/res_3/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_3/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTM("DELETE","/res_3/a1/a2/a3/a4/a5/a6","none");
+		TESTMA("DELETE","application/json","/res_3/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_3/a1/a2/a3/a4/a5/a6","none");
+		TESTM("GET","/res_3/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTMA("GET","application/json","/res_3/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_3/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTM("PUT","/res_3/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTMA("PUT","application/json","/res_3/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_3/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTM("POST","/res_3/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTMA("POST","application/json","/res_3/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_3/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTM("DELETE","/res_3/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMA("DELETE","application/json","/res_3/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_3/a1/a2/a3/a4/a5/a6/a7","none");
 		TESTM("GET","/res_3/a1/a2/a3/a4/a5/a6/a7/a8","get_8:1:2:3:4:5:6:7:8");
+		TESTMA("GET","application/json","/res_3/a1/a2/a3/a4/a5/a6/a7/a8","get_8:1:2:3:4:5:6:7:8");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_3/a1/a2/a3/a4/a5/a6/a7/a8","get_8:1:2:3:4:5:6:7:8");
+		TESTM("PUT","/res_3/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTMA("PUT","application/json","/res_3/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_3/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTM("POST","/res_3/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTMA("POST","application/json","/res_3/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_3/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTM("DELETE","/res_3/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMA("DELETE","application/json","/res_3/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_3/a1/a2/a3/a4/a5/a6/a7/a8","none");
+
+		TESTM("GET","/res_4","get_0");
+		TESTMA("GET","application/json","/res_4","get_0");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_4","get_0");
+		TESTM("PUT","/res_4","get_0");
+		TESTMA("PUT","application/json","/res_4","get_0");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_4","get_0");
+		TESTM("POST","/res_4","get_0");
+		TESTMA("POST","application/json","/res_4","get_0");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_4","get_0");
+		TESTM("DELETE","/res_4","get_0");
+		TESTMA("DELETE","application/json","/res_4","get_0");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_4","get_0");
+		TESTM("GET","/res_4/a1","get_1:1");
+		TESTMA("GET","application/json","/res_4/a1","get_1:1");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_4/a1","get_1:1");
+		TESTM("PUT","/res_4/a1","get_1:1");
+		TESTMA("PUT","application/json","/res_4/a1","get_1:1");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_4/a1","get_1:1");
+		TESTM("POST","/res_4/a1","get_1:1");
+		TESTMA("POST","application/json","/res_4/a1","get_1:1");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_4/a1","get_1:1");
+		TESTM("DELETE","/res_4/a1","get_1:1");
+		TESTMA("DELETE","application/json","/res_4/a1","get_1:1");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_4/a1","get_1:1");
+		TESTM("GET","/res_4/a1/a2","get_2:1:2");
+		TESTMA("GET","application/json","/res_4/a1/a2","get_2:1:2");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_4/a1/a2","get_2:1:2");
+		TESTM("PUT","/res_4/a1/a2","get_2:1:2");
+		TESTMA("PUT","application/json","/res_4/a1/a2","get_2:1:2");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_4/a1/a2","get_2:1:2");
+		TESTM("POST","/res_4/a1/a2","get_2:1:2");
+		TESTMA("POST","application/json","/res_4/a1/a2","get_2:1:2");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_4/a1/a2","get_2:1:2");
+		TESTM("DELETE","/res_4/a1/a2","get_2:1:2");
+		TESTMA("DELETE","application/json","/res_4/a1/a2","get_2:1:2");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_4/a1/a2","get_2:1:2");
+		TESTM("GET","/res_4/a1/a2/a3","get_3:1:2:3");
+		TESTMA("GET","application/json","/res_4/a1/a2/a3","get_3:1:2:3");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_4/a1/a2/a3","get_3:1:2:3");
+		TESTM("PUT","/res_4/a1/a2/a3","get_3:1:2:3");
+		TESTMA("PUT","application/json","/res_4/a1/a2/a3","get_3:1:2:3");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_4/a1/a2/a3","get_3:1:2:3");
+		TESTM("POST","/res_4/a1/a2/a3","get_3:1:2:3");
+		TESTMA("POST","application/json","/res_4/a1/a2/a3","get_3:1:2:3");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_4/a1/a2/a3","get_3:1:2:3");
+		TESTM("DELETE","/res_4/a1/a2/a3","get_3:1:2:3");
+		TESTMA("DELETE","application/json","/res_4/a1/a2/a3","get_3:1:2:3");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_4/a1/a2/a3","get_3:1:2:3");
+		TESTM("GET","/res_4/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTMA("GET","application/json","/res_4/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_4/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTM("PUT","/res_4/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTMA("PUT","application/json","/res_4/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_4/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTM("POST","/res_4/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTMA("POST","application/json","/res_4/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_4/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTM("DELETE","/res_4/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTMA("DELETE","application/json","/res_4/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_4/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTM("GET","/res_4/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTMA("GET","application/json","/res_4/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_4/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTM("PUT","/res_4/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTMA("PUT","application/json","/res_4/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_4/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTM("POST","/res_4/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTMA("POST","application/json","/res_4/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_4/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTM("DELETE","/res_4/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTMA("DELETE","application/json","/res_4/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_4/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTM("GET","/res_4/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTMA("GET","application/json","/res_4/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_4/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTM("PUT","/res_4/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTMA("PUT","application/json","/res_4/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_4/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTM("POST","/res_4/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTMA("POST","application/json","/res_4/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_4/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTM("DELETE","/res_4/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTMA("DELETE","application/json","/res_4/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_4/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTM("GET","/res_4/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTMA("GET","application/json","/res_4/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_4/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTM("PUT","/res_4/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTMA("PUT","application/json","/res_4/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_4/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTM("POST","/res_4/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTMA("POST","application/json","/res_4/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_4/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTM("DELETE","/res_4/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTMA("DELETE","application/json","/res_4/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_4/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
 		TESTM("GET","/res_4/a1/a2/a3/a4/a5/a6/a7/a8","get_8:1:2:3:4:5:6:7:8");
+		TESTMA("GET","application/json","/res_4/a1/a2/a3/a4/a5/a6/a7/a8","get_8:1:2:3:4:5:6:7:8");
+		TESTMACT("GET","application/json","application/json; utf-8","/res_4/a1/a2/a3/a4/a5/a6/a7/a8","get_8:1:2:3:4:5:6:7:8");
+		TESTM("PUT","/res_4/a1/a2/a3/a4/a5/a6/a7/a8","get_8:1:2:3:4:5:6:7:8");
+		TESTMA("PUT","application/json","/res_4/a1/a2/a3/a4/a5/a6/a7/a8","get_8:1:2:3:4:5:6:7:8");
+		TESTMACT("PUT","application/json","application/json; utf-8","/res_4/a1/a2/a3/a4/a5/a6/a7/a8","get_8:1:2:3:4:5:6:7:8");
+		TESTM("POST","/res_4/a1/a2/a3/a4/a5/a6/a7/a8","get_8:1:2:3:4:5:6:7:8");
+		TESTMA("POST","application/json","/res_4/a1/a2/a3/a4/a5/a6/a7/a8","get_8:1:2:3:4:5:6:7:8");
+		TESTMACT("POST","application/json","application/json; utf-8","/res_4/a1/a2/a3/a4/a5/a6/a7/a8","get_8:1:2:3:4:5:6:7:8");
+		TESTM("DELETE","/res_4/a1/a2/a3/a4/a5/a6/a7/a8","get_8:1:2:3:4:5:6:7:8");
+		TESTMA("DELETE","application/json","/res_4/a1/a2/a3/a4/a5/a6/a7/a8","get_8:1:2:3:4:5:6:7:8");
+		TESTMACT("DELETE","application/json","application/json; utf-8","/res_4/a1/a2/a3/a4/a5/a6/a7/a8","get_8:1:2:3:4:5:6:7:8");
+
+		TESTM("GET","/res_5","get_0");
+		TESTMA("GET","text/html,text/xhtml","/res_5","get_0");
+		TESTMA("GET","application/json","/res_5","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5","get_0");
+		TESTM("PUT","/res_5","p_0");
+		TESTMA("PUT","text/html,text/xhtml","/res_5","p_0");
+		TESTMA("PUT","application/json","/res_5","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5","p_0");
+		TESTM("POST","/res_5","p_0");
+		TESTMA("POST","text/html,text/xhtml","/res_5","p_0");
+		TESTMA("POST","application/json","/res_5","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5","p_0");
+		TESTM("DELETE","/res_5","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_5","none");
+		TESTMA("DELETE","application/json","/res_5","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5","none");
+		TESTM("GET","/res_5/a1","get_1:1");
+		TESTMA("GET","text/html,text/xhtml","/res_5/a1","get_1:1");
+		TESTMA("GET","application/json","/res_5/a1","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1","get_1:1");
+		TESTM("PUT","/res_5/a1","p_1:1");
+		TESTMA("PUT","text/html,text/xhtml","/res_5/a1","p_1:1");
+		TESTMA("PUT","application/json","/res_5/a1","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1","p_1:1");
+		TESTM("POST","/res_5/a1","p_1:1");
+		TESTMA("POST","text/html,text/xhtml","/res_5/a1","p_1:1");
+		TESTMA("POST","application/json","/res_5/a1","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1","p_1:1");
+		TESTM("DELETE","/res_5/a1","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_5/a1","none");
+		TESTMA("DELETE","application/json","/res_5/a1","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1","none");
+		TESTM("GET","/res_5/a1/a2","get_2:1:2");
+		TESTMA("GET","text/html,text/xhtml","/res_5/a1/a2","get_2:1:2");
+		TESTMA("GET","application/json","/res_5/a1/a2","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2","get_2:1:2");
+		TESTM("PUT","/res_5/a1/a2","p_2:1:2");
+		TESTMA("PUT","text/html,text/xhtml","/res_5/a1/a2","p_2:1:2");
+		TESTMA("PUT","application/json","/res_5/a1/a2","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2","p_2:1:2");
+		TESTM("POST","/res_5/a1/a2","p_2:1:2");
+		TESTMA("POST","text/html,text/xhtml","/res_5/a1/a2","p_2:1:2");
+		TESTMA("POST","application/json","/res_5/a1/a2","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2","p_2:1:2");
+		TESTM("DELETE","/res_5/a1/a2","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_5/a1/a2","none");
+		TESTMA("DELETE","application/json","/res_5/a1/a2","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2","none");
+		TESTM("GET","/res_5/a1/a2/a3","get_3:1:2:3");
+		TESTMA("GET","text/html,text/xhtml","/res_5/a1/a2/a3","get_3:1:2:3");
+		TESTMA("GET","application/json","/res_5/a1/a2/a3","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2/a3","get_3:1:2:3");
+		TESTM("PUT","/res_5/a1/a2/a3","p_3:1:2:3");
+		TESTMA("PUT","text/html,text/xhtml","/res_5/a1/a2/a3","p_3:1:2:3");
+		TESTMA("PUT","application/json","/res_5/a1/a2/a3","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2/a3","p_3:1:2:3");
+		TESTM("POST","/res_5/a1/a2/a3","p_3:1:2:3");
+		TESTMA("POST","text/html,text/xhtml","/res_5/a1/a2/a3","p_3:1:2:3");
+		TESTMA("POST","application/json","/res_5/a1/a2/a3","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2/a3","p_3:1:2:3");
+		TESTM("DELETE","/res_5/a1/a2/a3","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_5/a1/a2/a3","none");
+		TESTMA("DELETE","application/json","/res_5/a1/a2/a3","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2/a3","none");
+		TESTM("GET","/res_5/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTMA("GET","text/html,text/xhtml","/res_5/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTMA("GET","application/json","/res_5/a1/a2/a3/a4","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTM("PUT","/res_5/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTMA("PUT","text/html,text/xhtml","/res_5/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTMA("PUT","application/json","/res_5/a1/a2/a3/a4","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTM("POST","/res_5/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTMA("POST","text/html,text/xhtml","/res_5/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTMA("POST","application/json","/res_5/a1/a2/a3/a4","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTM("DELETE","/res_5/a1/a2/a3/a4","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_5/a1/a2/a3/a4","none");
+		TESTMA("DELETE","application/json","/res_5/a1/a2/a3/a4","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2/a3/a4","none");
+		TESTM("GET","/res_5/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTMA("GET","text/html,text/xhtml","/res_5/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTMA("GET","application/json","/res_5/a1/a2/a3/a4/a5","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTM("PUT","/res_5/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTMA("PUT","text/html,text/xhtml","/res_5/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTMA("PUT","application/json","/res_5/a1/a2/a3/a4/a5","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTM("POST","/res_5/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTMA("POST","text/html,text/xhtml","/res_5/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTMA("POST","application/json","/res_5/a1/a2/a3/a4/a5","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTM("DELETE","/res_5/a1/a2/a3/a4/a5","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_5/a1/a2/a3/a4/a5","none");
+		TESTMA("DELETE","application/json","/res_5/a1/a2/a3/a4/a5","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2/a3/a4/a5","none");
+		TESTM("GET","/res_5/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTMA("GET","text/html,text/xhtml","/res_5/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTMA("GET","application/json","/res_5/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTM("PUT","/res_5/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTMA("PUT","text/html,text/xhtml","/res_5/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTMA("PUT","application/json","/res_5/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTM("POST","/res_5/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTMA("POST","text/html,text/xhtml","/res_5/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTMA("POST","application/json","/res_5/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTM("DELETE","/res_5/a1/a2/a3/a4/a5/a6","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_5/a1/a2/a3/a4/a5/a6","none");
+		TESTMA("DELETE","application/json","/res_5/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2/a3/a4/a5/a6","none");
+		TESTM("GET","/res_5/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTMA("GET","text/html,text/xhtml","/res_5/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTMA("GET","application/json","/res_5/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTM("PUT","/res_5/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTMA("PUT","text/html,text/xhtml","/res_5/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTMA("PUT","application/json","/res_5/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTM("POST","/res_5/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTMA("POST","text/html,text/xhtml","/res_5/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTMA("POST","application/json","/res_5/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTM("DELETE","/res_5/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_5/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMA("DELETE","application/json","/res_5/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTM("GET","/res_5/a1/a2/a3/a4/a5/a6/a7/a8","get_8:1:2:3:4:5:6:7:8");
+		TESTMA("GET","text/html,text/xhtml","/res_5/a1/a2/a3/a4/a5/a6/a7/a8","get_8:1:2:3:4:5:6:7:8");
+		TESTMA("GET","application/json","/res_5/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2/a3/a4/a5/a6/a7/a8","get_8:1:2:3:4:5:6:7:8");
+		TESTM("PUT","/res_5/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTMA("PUT","text/html,text/xhtml","/res_5/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTMA("PUT","application/json","/res_5/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTM("POST","/res_5/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTMA("POST","text/html,text/xhtml","/res_5/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTMA("POST","application/json","/res_5/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTM("DELETE","/res_5/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_5/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMA("DELETE","application/json","/res_5/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_5/a1/a2/a3/a4/a5/a6/a7/a8","none");
+
+		TESTM("GET","/res_6","get_0");
+		TESTMA("GET","text/xhtml,text/html","/res_6","get_0");
+		TESTMA("GET","application/json","/res_6","none");
+		TESTMACT("GET","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6","get_0");
+		TESTM("PUT","/res_6","p_0");
+		TESTMA("PUT","text/xhtml,text/html","/res_6","p_0");
+		TESTMA("PUT","application/json","/res_6","none");
+		TESTMACT("PUT","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6","p_0");
+		TESTM("POST","/res_6","p_0");
+		TESTMA("POST","text/xhtml,text/html","/res_6","p_0");
+		TESTMA("POST","application/json","/res_6","none");
+		TESTMACT("POST","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6","p_0");
+		TESTM("DELETE","/res_6","none");
+		TESTMA("DELETE","text/xhtml,text/html","/res_6","none");
+		TESTMA("DELETE","application/json","/res_6","none");
+		TESTMACT("DELETE","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6","none");
+		TESTM("GET","/res_6/a1","get_1:1");
+		TESTMA("GET","text/xhtml,text/html","/res_6/a1","get_1:1");
+		TESTMA("GET","application/json","/res_6/a1","none");
+		TESTMACT("GET","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1","get_1:1");
+		TESTM("PUT","/res_6/a1","p_1:1");
+		TESTMA("PUT","text/xhtml,text/html","/res_6/a1","p_1:1");
+		TESTMA("PUT","application/json","/res_6/a1","none");
+		TESTMACT("PUT","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1","p_1:1");
+		TESTM("POST","/res_6/a1","p_1:1");
+		TESTMA("POST","text/xhtml,text/html","/res_6/a1","p_1:1");
+		TESTMA("POST","application/json","/res_6/a1","none");
+		TESTMACT("POST","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1","p_1:1");
+		TESTM("DELETE","/res_6/a1","none");
+		TESTMA("DELETE","text/xhtml,text/html","/res_6/a1","none");
+		TESTMA("DELETE","application/json","/res_6/a1","none");
+		TESTMACT("DELETE","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1","none");
+		TESTM("GET","/res_6/a1/a2","get_2:1:2");
+		TESTMA("GET","text/xhtml,text/html","/res_6/a1/a2","get_2:1:2");
+		TESTMA("GET","application/json","/res_6/a1/a2","none");
+		TESTMACT("GET","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2","get_2:1:2");
+		TESTM("PUT","/res_6/a1/a2","p_2:1:2");
+		TESTMA("PUT","text/xhtml,text/html","/res_6/a1/a2","p_2:1:2");
+		TESTMA("PUT","application/json","/res_6/a1/a2","none");
+		TESTMACT("PUT","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2","p_2:1:2");
+		TESTM("POST","/res_6/a1/a2","p_2:1:2");
+		TESTMA("POST","text/xhtml,text/html","/res_6/a1/a2","p_2:1:2");
+		TESTMA("POST","application/json","/res_6/a1/a2","none");
+		TESTMACT("POST","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2","p_2:1:2");
+		TESTM("DELETE","/res_6/a1/a2","none");
+		TESTMA("DELETE","text/xhtml,text/html","/res_6/a1/a2","none");
+		TESTMA("DELETE","application/json","/res_6/a1/a2","none");
+		TESTMACT("DELETE","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2","none");
+		TESTM("GET","/res_6/a1/a2/a3","get_3:1:2:3");
+		TESTMA("GET","text/xhtml,text/html","/res_6/a1/a2/a3","get_3:1:2:3");
+		TESTMA("GET","application/json","/res_6/a1/a2/a3","none");
+		TESTMACT("GET","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2/a3","get_3:1:2:3");
+		TESTM("PUT","/res_6/a1/a2/a3","p_3:1:2:3");
+		TESTMA("PUT","text/xhtml,text/html","/res_6/a1/a2/a3","p_3:1:2:3");
+		TESTMA("PUT","application/json","/res_6/a1/a2/a3","none");
+		TESTMACT("PUT","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2/a3","p_3:1:2:3");
+		TESTM("POST","/res_6/a1/a2/a3","p_3:1:2:3");
+		TESTMA("POST","text/xhtml,text/html","/res_6/a1/a2/a3","p_3:1:2:3");
+		TESTMA("POST","application/json","/res_6/a1/a2/a3","none");
+		TESTMACT("POST","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2/a3","p_3:1:2:3");
+		TESTM("DELETE","/res_6/a1/a2/a3","none");
+		TESTMA("DELETE","text/xhtml,text/html","/res_6/a1/a2/a3","none");
+		TESTMA("DELETE","application/json","/res_6/a1/a2/a3","none");
+		TESTMACT("DELETE","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2/a3","none");
+		TESTM("GET","/res_6/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTMA("GET","text/xhtml,text/html","/res_6/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTMA("GET","application/json","/res_6/a1/a2/a3/a4","none");
+		TESTMACT("GET","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2/a3/a4","get_4:1:2:3:4");
+		TESTM("PUT","/res_6/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTMA("PUT","text/xhtml,text/html","/res_6/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTMA("PUT","application/json","/res_6/a1/a2/a3/a4","none");
+		TESTMACT("PUT","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTM("POST","/res_6/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTMA("POST","text/xhtml,text/html","/res_6/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTMA("POST","application/json","/res_6/a1/a2/a3/a4","none");
+		TESTMACT("POST","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTM("DELETE","/res_6/a1/a2/a3/a4","none");
+		TESTMA("DELETE","text/xhtml,text/html","/res_6/a1/a2/a3/a4","none");
+		TESTMA("DELETE","application/json","/res_6/a1/a2/a3/a4","none");
+		TESTMACT("DELETE","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2/a3/a4","none");
+		TESTM("GET","/res_6/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTMA("GET","text/xhtml,text/html","/res_6/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTMA("GET","application/json","/res_6/a1/a2/a3/a4/a5","none");
+		TESTMACT("GET","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2/a3/a4/a5","get_5:1:2:3:4:5");
+		TESTM("PUT","/res_6/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTMA("PUT","text/xhtml,text/html","/res_6/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTMA("PUT","application/json","/res_6/a1/a2/a3/a4/a5","none");
+		TESTMACT("PUT","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTM("POST","/res_6/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTMA("POST","text/xhtml,text/html","/res_6/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTMA("POST","application/json","/res_6/a1/a2/a3/a4/a5","none");
+		TESTMACT("POST","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTM("DELETE","/res_6/a1/a2/a3/a4/a5","none");
+		TESTMA("DELETE","text/xhtml,text/html","/res_6/a1/a2/a3/a4/a5","none");
+		TESTMA("DELETE","application/json","/res_6/a1/a2/a3/a4/a5","none");
+		TESTMACT("DELETE","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2/a3/a4/a5","none");
+		TESTM("GET","/res_6/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTMA("GET","text/xhtml,text/html","/res_6/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTMA("GET","application/json","/res_6/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("GET","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2/a3/a4/a5/a6","get_6:1:2:3:4:5:6");
+		TESTM("PUT","/res_6/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTMA("PUT","text/xhtml,text/html","/res_6/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTMA("PUT","application/json","/res_6/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("PUT","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTM("POST","/res_6/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTMA("POST","text/xhtml,text/html","/res_6/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTMA("POST","application/json","/res_6/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("POST","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTM("DELETE","/res_6/a1/a2/a3/a4/a5/a6","none");
+		TESTMA("DELETE","text/xhtml,text/html","/res_6/a1/a2/a3/a4/a5/a6","none");
+		TESTMA("DELETE","application/json","/res_6/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("DELETE","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2/a3/a4/a5/a6","none");
+		TESTM("GET","/res_6/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTMA("GET","text/xhtml,text/html","/res_6/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTMA("GET","application/json","/res_6/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("GET","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2/a3/a4/a5/a6/a7","get_7:1:2:3:4:5:6:7");
+		TESTM("PUT","/res_6/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTMA("PUT","text/xhtml,text/html","/res_6/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTMA("PUT","application/json","/res_6/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("PUT","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTM("POST","/res_6/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTMA("POST","text/xhtml,text/html","/res_6/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTMA("POST","application/json","/res_6/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("POST","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTM("DELETE","/res_6/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMA("DELETE","text/xhtml,text/html","/res_6/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMA("DELETE","application/json","/res_6/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("DELETE","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTM("GET","/res_6/a1/a2/a3/a4/a5/a6/a7/a8","get_8:1:2:3:4:5:6:7:8");
+		TESTMA("GET","text/xhtml,text/html","/res_6/a1/a2/a3/a4/a5/a6/a7/a8","get_8:1:2:3:4:5:6:7:8");
+		TESTMA("GET","application/json","/res_6/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("GET","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2/a3/a4/a5/a6/a7/a8","get_8:1:2:3:4:5:6:7:8");
+		TESTM("PUT","/res_6/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTMA("PUT","text/xhtml,text/html","/res_6/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTMA("PUT","application/json","/res_6/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("PUT","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTM("POST","/res_6/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTMA("POST","text/xhtml,text/html","/res_6/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTMA("POST","application/json","/res_6/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("POST","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTM("DELETE","/res_6/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMA("DELETE","text/xhtml,text/html","/res_6/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMA("DELETE","application/json","/res_6/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("DELETE","text/xhtml,text/html","application/x-www-form-urlencoded; charset=utf-8","/res_6/a1/a2/a3/a4/a5/a6/a7/a8","none");
+
+		TESTM("GET","/res_7","none");
+		TESTMA("GET","text/html,text/xhtml","/res_7","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7","none");
+		TESTMACT("GET","text/html,text/xhtml","application/json; charset=utf-8","/res_7","none");
+		TESTMA("GET","application/json","/res_7","none");
+		TESTMACT("GET","application/json","application/json; charset=utf-8","/res_7","none");
+		TESTM("PUT","/res_7","none");
+		TESTMA("PUT","text/html,text/xhtml","/res_7","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7","p_0");
+		TESTMACT("PUT","text/html,text/xhtml","application/json; charset=utf-8","/res_7","none");
+		TESTMA("PUT","application/json","/res_7","none");
+		TESTMACT("PUT","application/json","application/json; charset=utf-8","/res_7","none");
+		TESTM("POST","/res_7","none");
+		TESTMA("POST","text/html,text/xhtml","/res_7","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7","p_0");
+		TESTMACT("POST","text/html,text/xhtml","application/json; charset=utf-8","/res_7","none");
+		TESTMA("POST","application/json","/res_7","none");
+		TESTMACT("POST","application/json","application/json; charset=utf-8","/res_7","none");
+		TESTM("DELETE","/res_7","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_7","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/json; charset=utf-8","/res_7","none");
+		TESTMA("DELETE","application/json","/res_7","none");
+		TESTMACT("DELETE","application/json","application/json; charset=utf-8","/res_7","none");
+		TESTM("GET","/res_7/a1","none");
+		TESTMA("GET","text/html,text/xhtml","/res_7/a1","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1","none");
+		TESTMACT("GET","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1","none");
+		TESTMA("GET","application/json","/res_7/a1","none");
+		TESTMACT("GET","application/json","application/json; charset=utf-8","/res_7/a1","none");
+		TESTM("PUT","/res_7/a1","none");
+		TESTMA("PUT","text/html,text/xhtml","/res_7/a1","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1","p_1:1");
+		TESTMACT("PUT","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1","none");
+		TESTMA("PUT","application/json","/res_7/a1","none");
+		TESTMACT("PUT","application/json","application/json; charset=utf-8","/res_7/a1","none");
+		TESTM("POST","/res_7/a1","none");
+		TESTMA("POST","text/html,text/xhtml","/res_7/a1","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1","p_1:1");
+		TESTMACT("POST","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1","none");
+		TESTMA("POST","application/json","/res_7/a1","none");
+		TESTMACT("POST","application/json","application/json; charset=utf-8","/res_7/a1","none");
+		TESTM("DELETE","/res_7/a1","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_7/a1","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1","none");
+		TESTMA("DELETE","application/json","/res_7/a1","none");
+		TESTMACT("DELETE","application/json","application/json; charset=utf-8","/res_7/a1","none");
+		TESTM("GET","/res_7/a1/a2","none");
+		TESTMA("GET","text/html,text/xhtml","/res_7/a1/a2","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2","none");
+		TESTMACT("GET","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2","none");
+		TESTMA("GET","application/json","/res_7/a1/a2","none");
+		TESTMACT("GET","application/json","application/json; charset=utf-8","/res_7/a1/a2","none");
+		TESTM("PUT","/res_7/a1/a2","none");
+		TESTMA("PUT","text/html,text/xhtml","/res_7/a1/a2","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2","p_2:1:2");
+		TESTMACT("PUT","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2","none");
+		TESTMA("PUT","application/json","/res_7/a1/a2","none");
+		TESTMACT("PUT","application/json","application/json; charset=utf-8","/res_7/a1/a2","none");
+		TESTM("POST","/res_7/a1/a2","none");
+		TESTMA("POST","text/html,text/xhtml","/res_7/a1/a2","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2","p_2:1:2");
+		TESTMACT("POST","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2","none");
+		TESTMA("POST","application/json","/res_7/a1/a2","none");
+		TESTMACT("POST","application/json","application/json; charset=utf-8","/res_7/a1/a2","none");
+		TESTM("DELETE","/res_7/a1/a2","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_7/a1/a2","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2","none");
+		TESTMA("DELETE","application/json","/res_7/a1/a2","none");
+		TESTMACT("DELETE","application/json","application/json; charset=utf-8","/res_7/a1/a2","none");
+		TESTM("GET","/res_7/a1/a2/a3","none");
+		TESTMA("GET","text/html,text/xhtml","/res_7/a1/a2/a3","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2/a3","none");
+		TESTMACT("GET","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2/a3","none");
+		TESTMA("GET","application/json","/res_7/a1/a2/a3","none");
+		TESTMACT("GET","application/json","application/json; charset=utf-8","/res_7/a1/a2/a3","none");
+		TESTM("PUT","/res_7/a1/a2/a3","none");
+		TESTMA("PUT","text/html,text/xhtml","/res_7/a1/a2/a3","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2/a3","p_3:1:2:3");
+		TESTMACT("PUT","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2/a3","none");
+		TESTMA("PUT","application/json","/res_7/a1/a2/a3","none");
+		TESTMACT("PUT","application/json","application/json; charset=utf-8","/res_7/a1/a2/a3","none");
+		TESTM("POST","/res_7/a1/a2/a3","none");
+		TESTMA("POST","text/html,text/xhtml","/res_7/a1/a2/a3","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2/a3","p_3:1:2:3");
+		TESTMACT("POST","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2/a3","none");
+		TESTMA("POST","application/json","/res_7/a1/a2/a3","none");
+		TESTMACT("POST","application/json","application/json; charset=utf-8","/res_7/a1/a2/a3","none");
+		TESTM("DELETE","/res_7/a1/a2/a3","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_7/a1/a2/a3","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2/a3","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2/a3","none");
+		TESTMA("DELETE","application/json","/res_7/a1/a2/a3","none");
+		TESTMACT("DELETE","application/json","application/json; charset=utf-8","/res_7/a1/a2/a3","none");
+		TESTM("GET","/res_7/a1/a2/a3/a4","none");
+		TESTMA("GET","text/html,text/xhtml","/res_7/a1/a2/a3/a4","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2/a3/a4","none");
+		TESTMACT("GET","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2/a3/a4","none");
+		TESTMA("GET","application/json","/res_7/a1/a2/a3/a4","none");
+		TESTMACT("GET","application/json","application/json; charset=utf-8","/res_7/a1/a2/a3/a4","none");
+		TESTM("PUT","/res_7/a1/a2/a3/a4","none");
+		TESTMA("PUT","text/html,text/xhtml","/res_7/a1/a2/a3/a4","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTMACT("PUT","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2/a3/a4","none");
+		TESTMA("PUT","application/json","/res_7/a1/a2/a3/a4","none");
+		TESTMACT("PUT","application/json","application/json; charset=utf-8","/res_7/a1/a2/a3/a4","none");
+		TESTM("POST","/res_7/a1/a2/a3/a4","none");
+		TESTMA("POST","text/html,text/xhtml","/res_7/a1/a2/a3/a4","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTMACT("POST","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2/a3/a4","none");
+		TESTMA("POST","application/json","/res_7/a1/a2/a3/a4","none");
+		TESTMACT("POST","application/json","application/json; charset=utf-8","/res_7/a1/a2/a3/a4","none");
+		TESTM("DELETE","/res_7/a1/a2/a3/a4","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_7/a1/a2/a3/a4","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2/a3/a4","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2/a3/a4","none");
+		TESTMA("DELETE","application/json","/res_7/a1/a2/a3/a4","none");
+		TESTMACT("DELETE","application/json","application/json; charset=utf-8","/res_7/a1/a2/a3/a4","none");
+		TESTM("GET","/res_7/a1/a2/a3/a4/a5","none");
+		TESTMA("GET","text/html,text/xhtml","/res_7/a1/a2/a3/a4/a5","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2/a3/a4/a5","none");
+		TESTMACT("GET","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5","none");
+		TESTMA("GET","application/json","/res_7/a1/a2/a3/a4/a5","none");
+		TESTMACT("GET","application/json","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5","none");
+		TESTM("PUT","/res_7/a1/a2/a3/a4/a5","none");
+		TESTMA("PUT","text/html,text/xhtml","/res_7/a1/a2/a3/a4/a5","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTMACT("PUT","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5","none");
+		TESTMA("PUT","application/json","/res_7/a1/a2/a3/a4/a5","none");
+		TESTMACT("PUT","application/json","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5","none");
+		TESTM("POST","/res_7/a1/a2/a3/a4/a5","none");
+		TESTMA("POST","text/html,text/xhtml","/res_7/a1/a2/a3/a4/a5","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTMACT("POST","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5","none");
+		TESTMA("POST","application/json","/res_7/a1/a2/a3/a4/a5","none");
+		TESTMACT("POST","application/json","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5","none");
+		TESTM("DELETE","/res_7/a1/a2/a3/a4/a5","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_7/a1/a2/a3/a4/a5","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2/a3/a4/a5","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5","none");
+		TESTMA("DELETE","application/json","/res_7/a1/a2/a3/a4/a5","none");
+		TESTMACT("DELETE","application/json","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5","none");
+		TESTM("GET","/res_7/a1/a2/a3/a4/a5/a6","none");
+		TESTMA("GET","text/html,text/xhtml","/res_7/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("GET","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6","none");
+		TESTMA("GET","application/json","/res_7/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("GET","application/json","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6","none");
+		TESTM("PUT","/res_7/a1/a2/a3/a4/a5/a6","none");
+		TESTMA("PUT","text/html,text/xhtml","/res_7/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTMACT("PUT","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6","none");
+		TESTMA("PUT","application/json","/res_7/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("PUT","application/json","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6","none");
+		TESTM("POST","/res_7/a1/a2/a3/a4/a5/a6","none");
+		TESTMA("POST","text/html,text/xhtml","/res_7/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTMACT("POST","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6","none");
+		TESTMA("POST","application/json","/res_7/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("POST","application/json","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6","none");
+		TESTM("DELETE","/res_7/a1/a2/a3/a4/a5/a6","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_7/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6","none");
+		TESTMA("DELETE","application/json","/res_7/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("DELETE","application/json","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6","none");
+		TESTM("GET","/res_7/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMA("GET","text/html,text/xhtml","/res_7/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("GET","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMA("GET","application/json","/res_7/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("GET","application/json","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTM("PUT","/res_7/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMA("PUT","text/html,text/xhtml","/res_7/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTMACT("PUT","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMA("PUT","application/json","/res_7/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("PUT","application/json","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTM("POST","/res_7/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMA("POST","text/html,text/xhtml","/res_7/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTMACT("POST","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMA("POST","application/json","/res_7/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("POST","application/json","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTM("DELETE","/res_7/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_7/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMA("DELETE","application/json","/res_7/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("DELETE","application/json","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTM("GET","/res_7/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMA("GET","text/html,text/xhtml","/res_7/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("GET","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMA("GET","application/json","/res_7/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("GET","application/json","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTM("PUT","/res_7/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMA("PUT","text/html,text/xhtml","/res_7/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTMACT("PUT","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMA("PUT","application/json","/res_7/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("PUT","application/json","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTM("POST","/res_7/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMA("POST","text/html,text/xhtml","/res_7/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTMACT("POST","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMA("POST","application/json","/res_7/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("POST","application/json","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTM("DELETE","/res_7/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_7/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMA("DELETE","application/json","/res_7/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("DELETE","application/json","application/json; charset=utf-8","/res_7/a1/a2/a3/a4/a5/a6/a7/a8","none");
+
+		TESTM("GET","/res_8","none");
+		TESTMA("GET","text/html,text/xhtml","/res_8","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8","none");
+		TESTMACT("GET","text/html,text/xhtml","application/json; charset=utf-8","/res_8","none");
+		TESTMA("GET","application/json","/res_8","none");
+		TESTMACT("GET","application/json","application/json; charset=utf-8","/res_8","none");
+		TESTM("PUT","/res_8","none");
+		TESTMA("PUT","text/html,text/xhtml","/res_8","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8","p_0");
+		TESTMACT("PUT","text/html,text/xhtml","application/json; charset=utf-8","/res_8","none");
+		TESTMA("PUT","application/json","/res_8","none");
+		TESTMACT("PUT","application/json","application/json; charset=utf-8","/res_8","none");
+		TESTM("POST","/res_8","none");
+		TESTMA("POST","text/html,text/xhtml","/res_8","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8","p_0");
+		TESTMACT("POST","text/html,text/xhtml","application/json; charset=utf-8","/res_8","none");
+		TESTMA("POST","application/json","/res_8","none");
+		TESTMACT("POST","application/json","application/json; charset=utf-8","/res_8","none");
+		TESTM("DELETE","/res_8","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_8","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/json; charset=utf-8","/res_8","none");
+		TESTMA("DELETE","application/json","/res_8","none");
+		TESTMACT("DELETE","application/json","application/json; charset=utf-8","/res_8","none");
+		TESTM("GET","/res_8/a1","none");
+		TESTMA("GET","text/html,text/xhtml","/res_8/a1","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1","none");
+		TESTMACT("GET","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1","none");
+		TESTMA("GET","application/json","/res_8/a1","none");
+		TESTMACT("GET","application/json","application/json; charset=utf-8","/res_8/a1","none");
+		TESTM("PUT","/res_8/a1","none");
+		TESTMA("PUT","text/html,text/xhtml","/res_8/a1","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1","p_1:1");
+		TESTMACT("PUT","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1","none");
+		TESTMA("PUT","application/json","/res_8/a1","none");
+		TESTMACT("PUT","application/json","application/json; charset=utf-8","/res_8/a1","none");
+		TESTM("POST","/res_8/a1","none");
+		TESTMA("POST","text/html,text/xhtml","/res_8/a1","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1","p_1:1");
+		TESTMACT("POST","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1","none");
+		TESTMA("POST","application/json","/res_8/a1","none");
+		TESTMACT("POST","application/json","application/json; charset=utf-8","/res_8/a1","none");
+		TESTM("DELETE","/res_8/a1","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_8/a1","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1","none");
+		TESTMA("DELETE","application/json","/res_8/a1","none");
+		TESTMACT("DELETE","application/json","application/json; charset=utf-8","/res_8/a1","none");
+		TESTM("GET","/res_8/a1/a2","none");
+		TESTMA("GET","text/html,text/xhtml","/res_8/a1/a2","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2","none");
+		TESTMACT("GET","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2","none");
+		TESTMA("GET","application/json","/res_8/a1/a2","none");
+		TESTMACT("GET","application/json","application/json; charset=utf-8","/res_8/a1/a2","none");
+		TESTM("PUT","/res_8/a1/a2","none");
+		TESTMA("PUT","text/html,text/xhtml","/res_8/a1/a2","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2","p_2:1:2");
+		TESTMACT("PUT","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2","none");
+		TESTMA("PUT","application/json","/res_8/a1/a2","none");
+		TESTMACT("PUT","application/json","application/json; charset=utf-8","/res_8/a1/a2","none");
+		TESTM("POST","/res_8/a1/a2","none");
+		TESTMA("POST","text/html,text/xhtml","/res_8/a1/a2","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2","p_2:1:2");
+		TESTMACT("POST","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2","none");
+		TESTMA("POST","application/json","/res_8/a1/a2","none");
+		TESTMACT("POST","application/json","application/json; charset=utf-8","/res_8/a1/a2","none");
+		TESTM("DELETE","/res_8/a1/a2","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_8/a1/a2","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2","none");
+		TESTMA("DELETE","application/json","/res_8/a1/a2","none");
+		TESTMACT("DELETE","application/json","application/json; charset=utf-8","/res_8/a1/a2","none");
+		TESTM("GET","/res_8/a1/a2/a3","none");
+		TESTMA("GET","text/html,text/xhtml","/res_8/a1/a2/a3","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2/a3","none");
+		TESTMACT("GET","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2/a3","none");
+		TESTMA("GET","application/json","/res_8/a1/a2/a3","none");
+		TESTMACT("GET","application/json","application/json; charset=utf-8","/res_8/a1/a2/a3","none");
+		TESTM("PUT","/res_8/a1/a2/a3","none");
+		TESTMA("PUT","text/html,text/xhtml","/res_8/a1/a2/a3","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2/a3","p_3:1:2:3");
+		TESTMACT("PUT","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2/a3","none");
+		TESTMA("PUT","application/json","/res_8/a1/a2/a3","none");
+		TESTMACT("PUT","application/json","application/json; charset=utf-8","/res_8/a1/a2/a3","none");
+		TESTM("POST","/res_8/a1/a2/a3","none");
+		TESTMA("POST","text/html,text/xhtml","/res_8/a1/a2/a3","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2/a3","p_3:1:2:3");
+		TESTMACT("POST","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2/a3","none");
+		TESTMA("POST","application/json","/res_8/a1/a2/a3","none");
+		TESTMACT("POST","application/json","application/json; charset=utf-8","/res_8/a1/a2/a3","none");
+		TESTM("DELETE","/res_8/a1/a2/a3","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_8/a1/a2/a3","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2/a3","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2/a3","none");
+		TESTMA("DELETE","application/json","/res_8/a1/a2/a3","none");
+		TESTMACT("DELETE","application/json","application/json; charset=utf-8","/res_8/a1/a2/a3","none");
+		TESTM("GET","/res_8/a1/a2/a3/a4","none");
+		TESTMA("GET","text/html,text/xhtml","/res_8/a1/a2/a3/a4","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2/a3/a4","none");
+		TESTMACT("GET","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2/a3/a4","none");
+		TESTMA("GET","application/json","/res_8/a1/a2/a3/a4","none");
+		TESTMACT("GET","application/json","application/json; charset=utf-8","/res_8/a1/a2/a3/a4","none");
+		TESTM("PUT","/res_8/a1/a2/a3/a4","none");
+		TESTMA("PUT","text/html,text/xhtml","/res_8/a1/a2/a3/a4","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTMACT("PUT","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2/a3/a4","none");
+		TESTMA("PUT","application/json","/res_8/a1/a2/a3/a4","none");
+		TESTMACT("PUT","application/json","application/json; charset=utf-8","/res_8/a1/a2/a3/a4","none");
+		TESTM("POST","/res_8/a1/a2/a3/a4","none");
+		TESTMA("POST","text/html,text/xhtml","/res_8/a1/a2/a3/a4","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2/a3/a4","p_4:1:2:3:4");
+		TESTMACT("POST","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2/a3/a4","none");
+		TESTMA("POST","application/json","/res_8/a1/a2/a3/a4","none");
+		TESTMACT("POST","application/json","application/json; charset=utf-8","/res_8/a1/a2/a3/a4","none");
+		TESTM("DELETE","/res_8/a1/a2/a3/a4","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_8/a1/a2/a3/a4","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2/a3/a4","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2/a3/a4","none");
+		TESTMA("DELETE","application/json","/res_8/a1/a2/a3/a4","none");
+		TESTMACT("DELETE","application/json","application/json; charset=utf-8","/res_8/a1/a2/a3/a4","none");
+		TESTM("GET","/res_8/a1/a2/a3/a4/a5","none");
+		TESTMA("GET","text/html,text/xhtml","/res_8/a1/a2/a3/a4/a5","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2/a3/a4/a5","none");
+		TESTMACT("GET","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5","none");
+		TESTMA("GET","application/json","/res_8/a1/a2/a3/a4/a5","none");
+		TESTMACT("GET","application/json","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5","none");
+		TESTM("PUT","/res_8/a1/a2/a3/a4/a5","none");
+		TESTMA("PUT","text/html,text/xhtml","/res_8/a1/a2/a3/a4/a5","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTMACT("PUT","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5","none");
+		TESTMA("PUT","application/json","/res_8/a1/a2/a3/a4/a5","none");
+		TESTMACT("PUT","application/json","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5","none");
+		TESTM("POST","/res_8/a1/a2/a3/a4/a5","none");
+		TESTMA("POST","text/html,text/xhtml","/res_8/a1/a2/a3/a4/a5","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2/a3/a4/a5","p_5:1:2:3:4:5");
+		TESTMACT("POST","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5","none");
+		TESTMA("POST","application/json","/res_8/a1/a2/a3/a4/a5","none");
+		TESTMACT("POST","application/json","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5","none");
+		TESTM("DELETE","/res_8/a1/a2/a3/a4/a5","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_8/a1/a2/a3/a4/a5","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2/a3/a4/a5","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5","none");
+		TESTMA("DELETE","application/json","/res_8/a1/a2/a3/a4/a5","none");
+		TESTMACT("DELETE","application/json","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5","none");
+		TESTM("GET","/res_8/a1/a2/a3/a4/a5/a6","none");
+		TESTMA("GET","text/html,text/xhtml","/res_8/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("GET","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6","none");
+		TESTMA("GET","application/json","/res_8/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("GET","application/json","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6","none");
+		TESTM("PUT","/res_8/a1/a2/a3/a4/a5/a6","none");
+		TESTMA("PUT","text/html,text/xhtml","/res_8/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTMACT("PUT","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6","none");
+		TESTMA("PUT","application/json","/res_8/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("PUT","application/json","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6","none");
+		TESTM("POST","/res_8/a1/a2/a3/a4/a5/a6","none");
+		TESTMA("POST","text/html,text/xhtml","/res_8/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6","p_6:1:2:3:4:5:6");
+		TESTMACT("POST","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6","none");
+		TESTMA("POST","application/json","/res_8/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("POST","application/json","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6","none");
+		TESTM("DELETE","/res_8/a1/a2/a3/a4/a5/a6","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_8/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6","none");
+		TESTMA("DELETE","application/json","/res_8/a1/a2/a3/a4/a5/a6","none");
+		TESTMACT("DELETE","application/json","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6","none");
+		TESTM("GET","/res_8/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMA("GET","text/html,text/xhtml","/res_8/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("GET","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMA("GET","application/json","/res_8/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("GET","application/json","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTM("PUT","/res_8/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMA("PUT","text/html,text/xhtml","/res_8/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTMACT("PUT","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMA("PUT","application/json","/res_8/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("PUT","application/json","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTM("POST","/res_8/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMA("POST","text/html,text/xhtml","/res_8/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6/a7","p_7:1:2:3:4:5:6:7");
+		TESTMACT("POST","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMA("POST","application/json","/res_8/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("POST","application/json","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTM("DELETE","/res_8/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_8/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMA("DELETE","application/json","/res_8/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTMACT("DELETE","application/json","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6/a7","none");
+		TESTM("GET","/res_8/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMA("GET","text/html,text/xhtml","/res_8/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("GET","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("GET","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMA("GET","application/json","/res_8/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("GET","application/json","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTM("PUT","/res_8/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMA("PUT","text/html,text/xhtml","/res_8/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("PUT","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTMACT("PUT","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMA("PUT","application/json","/res_8/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("PUT","application/json","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTM("POST","/res_8/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMA("POST","text/html,text/xhtml","/res_8/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("POST","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6/a7/a8","p_8:1:2:3:4:5:6:7:8");
+		TESTMACT("POST","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMA("POST","application/json","/res_8/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("POST","application/json","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTM("DELETE","/res_8/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMA("DELETE","text/html,text/xhtml","/res_8/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/x-www-form-urlencoded; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("DELETE","text/html,text/xhtml","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMA("DELETE","application/json","/res_8/a1/a2/a3/a4/a5/a6/a7/a8","none");
+		TESTMACT("DELETE","application/json","application/json; charset=utf-8","/res_8/a1/a2/a3/a4/a5/a6/a7/a8","none");
 	}
-	void set_context(std::string const &method="GET")
+	void set_context(std::string const &method="GET", std::string const &accept="*/*", std::string const &content_type="")
 	{
 		std::map<std::string,std::string> env;
 		env["HTTP_HOST"]="www.example.com";
 		env["SCRIPT_NAME"]="/foo";
 		env["PATH_INFO"]="/bar";
 		env["REQUEST_METHOD"]=method;
+		if(!accept.empty())
+			env["HTTP_ACCEPT"]=accept;
+		if(!content_type.empty())
+			env["CONTENT_TYPE"]=content_type;
 		env["HTTP_ACCEPT_ENCODING"]="gzip";
 		booster::shared_ptr<dummy_api> api(new dummy_api(service(),env,output_));
-		booster::shared_ptr<cppcms::http::context> cnt(new cppcms::http::context(api));
+		booster::shared_ptr<dummy_http_context> cnt(new dummy_http_context(api));
 		assign_context(cnt);
 		response().io_mode(cppcms::http::response::normal);
 		output_.clear();
 	}
-
+	
 	std::string v_;
 	std::string output_;
 };


### PR DESCRIPTION
- the response mime type will be checked against the HTTP Accept Header
- the response mime type will be set for the response
- the request mime type will checked against the Content Type of the request

example:

`dispatcher().map("(PUT|POST)",
						 "text/html",
						 "application/x-www-form-urlencoded",
						 "/res_7/(a(\\d+))/(a(\\d+))/(a(\\d+))",
						 &disp::p_3,this,2,4,6);`

This will e.g. map correctly with a request with:
- PUT as HTTP request method
- text/html,text/xhtml as HTTP Accept
- application/x-www-form-urlencoded; charset=utf-8 as HTTP request content type

More information / examples can be found in the code documentation (url_dispatcher.h) or the unit tests (url_mapper_test.cpp)