### PR TITLE
Python 3.12 compatibility: wrap regex in r''.

### DIFF
--- a/bin/cppcms_tmpl_cc
+++ b/bin/cppcms_tmpl_cc
@@ -220,7 +220,7 @@ class template_block:
         self.name=m.group(1)
         params=""
         abstract = m.group('abs') != None
-        if m.group(2) and not re.match('^\s*$',m.group(2)):
+        if m.group(2) and not re.match(r'^\s*$',m.group(2)):
             params=self.create_parameters(m.group(2))
         if abstract:
             output_declaration( "virtual void %s(%s) = 0;" % (self.name,params) )
@@ -310,7 +310,7 @@ def make_ident(val):
     global tmpl_seq
     if m.group(1) in tmpl_seq:
         return val
-    m2=re.match('^\*(.*)$',val)
+    m2=re.match(r'^\*(.*)$',val)
     if m2:
         return "*content." + m2.group(1)
     else:
@@ -342,7 +342,7 @@ class using_block:
             + r'(\s*(?P<fst_str>'+ str_match +r')|(?:\s+(?P<fst_var>' + variable_match + r')))' \
             + r'(\s*,\s*((?P<snd_str>'+ str_match +r')|(?P<snd_var>' + variable_match + r')))?' \
             + r')?' \
-        + '\s*%>$'
+        + r'\s*%>$'
     basic_pattern = 'using'
     basic_name = 'using'
     type='using'
@@ -362,7 +362,7 @@ class foreach_block:
     pattern=r'^<%\s*foreach\s+([a-zA-Z]\w*)(\s+as\s+((:?:?\w+)(::\w+)*))?' \
         + r'(?:\s+rowid\s+([a-zA-Z]\w*)(?:\s+from\s+(\d+))?)?' \
         + r'(?:\s+(reverse))?' \
-        + '\s+in\s+(' + variable_match +')\s*%>$'
+        + r'\s+in\s+(' + variable_match + r')\s*%>$'
     basic_pattern = 'foreach'
     basic_name = 'foreach'
     type='foreach'
@@ -521,7 +521,7 @@ class else_block:
         stack.append(self)
 
 class if_block:
-    pattern=r'^<%\s*(if|elif)\s+((not\s+|not\s+empty\s+|empty\s+)?('+variable_match+')|\((.+)\)|)\s*%>$'
+    pattern=r'^<%\s*(if|elif)\s+((not\s+|not\s+empty\s+|empty\s+)?(' + variable_match + r')|\((.+)\)|)\s*%>$'
     basic_pattern = '(if|elif)'
     basic_name = 'if/elif'
     type='if'
@@ -609,7 +609,7 @@ class domain_block:
 
 class cpp_include_block:
     pattern=r'^<%\s*c\+\+(src)?\s+(.*)%>$'
-    basic_pattern = 'c\+\+(src)?'
+    basic_pattern = r'c\+\+(src)?'
     basic_name = 'c++'
     def use(self,m):
         global inline_cpp_to
@@ -626,11 +626,11 @@ def get_filter(cur):
 
 class base_show:
     mark='('+variable_match+r')\s*(\|(.*))?'
-    base_pattern='^\s*'+mark + '$'
+    base_pattern=r'^\s*'+mark + '$'
     def __init__(self,default_filter=None):
         self.default_filter=default_filter
     def get_params(self,s):
-        pattern='^\s*(('+variable_match+')|('+str_match+')|(\-?\d+(\.\d*)?))\s*(,(.*))?$'
+        pattern=r'^\s*((' + variable_match + ')|(' + str_match + r')|(\-?\d+(\.\d*)?))\s*(,(.*))?$'
         res=[]
         m=re.match(pattern,s)
         while m:
@@ -656,7 +656,7 @@ class base_show:
         if not m.group(8):
             return "%s(%s)" % (get_filter(self.default_filter), var)
         filters=m.group(8)
-        expr='^\s*(ext\s+)?(\w+)\s*(\((([^"\)]|'+str_match + ')*)\))?\s*(\|(.*))?$'
+        expr=r'^\s*(ext\s+)?(\w+)\s*(\((([^"\)]|' + str_match + r')*)\))?\s*(\|(.*))?$'
         m=re.match(expr,filters)
         while m:
             if m.group(1):
@@ -678,7 +678,7 @@ class base_show:
 
 class form_block:
     pattern=r'^<%\s*form\s+(as_p|as_table|as_ul|as_dl|as_space|input|block|begin|end)\s+('\
-         + variable_match +')\s*%>$'
+         + variable_match + r')\s*%>$'
 
     basic_pattern  = 'form'
     basic_name = 'form'
@@ -796,7 +796,7 @@ class filters_show_block(base_show):
             output_template('out()<<%s;' % expr)
 
 def make_format_params(s,default_filter = None):
-    pattern=r'^(([^,\("]|'+str_match+'|\(([^"\)]|'+str_match+')*\))+)(,(.*))?$'
+    pattern=r'^(([^,\("]|' + str_match + r'|\(([^"\)]|' + str_match + r')*\))+)(,(.*))?$'
     params=[]
     m=re.match(pattern,s)
     s_orig=s
@@ -835,7 +835,7 @@ class cache_block:
             r'(\s+for\s+(?P<time>\d+))?(\s+on\s+miss\s+(?P<callback>[a-zA-Z]\w*)\(\))?' \
             + r'(?P<notriggers>\s+no\s+triggers)?' \
             + r'(?P<norecording>\s+no\s+recording)?' \
-            + '\s*%>$'
+            + r'\s*%>$'
     basic_pattern = 'cache'
     basic_name = 'cache'
     type = 'cache'
@@ -894,7 +894,7 @@ class trigger_block:
 
 
 class ngettext_block:
-    pattern=r'^<%\s*ngt\s*((?:' + str_match + '\s*,\s*)?'+str_match+')\s*,\s*('+str_match+')\s*,\s*('+variable_match+')\s*(using(.*))?\s*%>$'
+    pattern=r'^<%\s*ngt\s*((?:' + str_match + r'\s*,\s*)?' + str_match + r')\s*,\s*(' + str_match + r')\s*,\s*(' + variable_match + r')\s*(using(.*))?\s*%>$'
     basic_pattern = 'ngt'
     basic_name = 'ngt'
     def use(self,m):
@@ -912,7 +912,7 @@ class ngettext_block:
 
 
 class gettext_block:
-    pattern=r'^<%\s*gt\s*((?:' + str_match + '\s*,\s*)?'  +str_match+')\s*(using(.*))?\s*%>$'
+    pattern=r'^<%\s*gt\s*((?:' + str_match + r'\s*,\s*)?'  + str_match + r')\s*(using(.*))?\s*%>$'
     basic_pattern = 'gt'
     basic_name = 'gt'
     def use(self,m):
@@ -927,7 +927,7 @@ class gettext_block:
             output_template( "out()<<cppcms::locale::format(cppcms::locale::translate(%s)) %% (%s);" % (s , ') % ('.join(params)))
 
 class url_block:
-    pattern=r'^<%\s*url\s*('+str_match+')\s*(using(.*))?\s*%>$'
+    pattern=r'^<%\s*url\s*(' + str_match + r')\s*(using(.*))?\s*%>$'
     basic_pattern = 'url'
     basic_name = 'url'
     def use(self,m):


### PR DESCRIPTION
Fixes scores of errors like:
	SyntaxWarning: invalid escape sequence '\*'

Using invalid escape sequences in string literals has been deprecated since Python 3.6. Since then, attempting to use an invalid escape sequence has emitted a DeprecationWarning. Python 3.12 upgraded the DeprecationWarning to a SyntaxWarning.