### PR TITLE
CMakeLists.txt: allow flags passed on the command line to win over bu…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,8 +141,8 @@ elseif(MSVC)
 	set(C_FLAGS "/W3")
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS}")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${C_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
+set(CMAKE_C_FLAGS "${C_FLAGS} ${CMAKE_C_FLAGS} ")
 
 #############################################################################
 #

--- a/booster/CMakeLists.txt
+++ b/booster/CMakeLists.txt
@@ -223,7 +223,7 @@ if(NOT IS_WINDOWS)
 	endif()
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
 
 #############################################################################
 #


### PR DESCRIPTION
…ilt-in flags

CMakeLists.txt and booster/CMakeLists.txt define some flags in CXX_FLAGS, and then set CMAKE_CXX_FLAGS in a way that causes the flags in CXX_FLAGS to override the ones passed (for example on the command line through CMAKE_CXX_FLAGS). This prevents the user from overriding those compiler flags in CXX_FLAGS.

A specific example is that CXX_FLAGS sets -std=c++11, but with recent version of ICU (such as >= 77-1), -std=c++11 is not enough, passing -std=c++17 is needed. Unfortunately, it cannot be passed through CMAKE_CXX_FLAGS due to the aforementioned problem.

This commit allows to resolve this by ensuring that CMAKE_CXX_FLAGS and CMAKE_C_FLAGS win over CXX_FLAGS/C_FLAGS.