### PR TITLE
Make the lib compile on Ubuntu 25.10+26.04. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12..4.3)
 set(CMAKE_LEGACY_CYGWIN_WIN32 0)
 
 
@@ -109,7 +109,7 @@ endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX)
 
-	set(CXX_FLAGS "-Wall -Wextra -std=c++11")
+	set(CXX_FLAGS "-Wall -Wextra -std=c++17")
 	set(C_FLAGS "-Wall -Wextra")
 
 	if(CMAKE_SYSTEM_NAME STREQUAL "SunOS")

--- a/booster/CMakeLists.txt
+++ b/booster/CMakeLists.txt
@@ -6,7 +6,7 @@
 #  http://www.boost.org/LICENSE_1_0.txt)
 #
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12..99.0)
 project(booster)
 include(CheckFunctionExists)
 include(CheckCXXSourceCompiles)
@@ -197,7 +197,7 @@ endif()
 #############################################################################
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-	set(CXX_FLAGS "-Wall -Wextra -std=c++11")
+	set(CXX_FLAGS "-Wall -Wextra -std=c++17")
 
 	if(CMAKE_SYSTEM_NAME STREQUAL "SunOS")
 		set(CXX_FLAGS "${CXX_FLAGS} -pthreads")


### PR DESCRIPTION
Compile fails without C++17. I have tested up to CMake 4.3.2.

I have set booster to not fail on new CMake versions for some time.

I have tested this (using Docker) on Ubuntu 22.04, Ubuntu 26.04, and Debian 13.

I have only touched the gcc path as it is the only one I can reliable test.

It currently fails with errors like:
```
/usr/include/unicode/char16ptr.h:370:36: note: ‘std::enable_if_t’ is only available from C++14 onwards
/usr/include/unicode/char16ptr.h:370:47: error: expected ‘>’ before ‘<’ token
  370 |           typename = typename std::enable_if_t<std::is_pointer_v<std::remove_reference_t<T>>>,
```
I found that I needed C++17 to make it compile. It does give some deprecation warnings about std::iterator but it works.